### PR TITLE
fix the site_name of mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 # Project information
-site_name: 쿠브네티스 스쿨
+site_name: 쿠버네티스 스쿨
 site_url: https://cloudacode.com/hello-kubernetes/
 site_author: kcfigaro@gmail.com, juner84s@gmail.com, steven.hj.shim@gmail.com
 site_description: >-


### PR DESCRIPTION
chage site_name to '쿠버네티스 스쿨' from '쿠브네티스 스쿨'

의도하신건지 오타인지 몰라 수정 제안을 드려봅니다.

(다른 곳에서는 쿠버네티스 스쿨로 쓰고 계셔서..ㅎㅎ)